### PR TITLE
Add fix_language / mode_unlock / chs_patch For JPN39 (Thanks to @CottonGuard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ unlock_songs = true
   mode_collabo026 = false
 
   [patches.jpn39]
+  # sync test mode language to attract etc
+  fix_language = false
   # use cn font and chineseS wordlist value
   chs_patch = false
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ unlock_songs = true
   # enable ai soshina mode
   mode_collabo026 = false
 
+  [patches.jpn39]
+  # use cn font and chineseS wordlist value
+  chs_patch = false
+
 [audio]
 # wasapi shared mode
 # allows you to have multiple audio sources at once at a cost of having higher latency

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ unlock_songs = true
   fix_language = false
   # use cn font and chineseS wordlist value
   chs_patch = false
+  # enable one piece collab mode
+  mode_collabo025 = false
+  # enable ai soshina mode
+  mode_collabo026 = false
+  # enable aoharu no tatsujinn mode
+  mode_aprilfool001 = false
 
 [audio]
 # wasapi shared mode

--- a/dist/config.toml
+++ b/dist/config.toml
@@ -16,6 +16,9 @@ unlock_songs = true
   mode_collabo025 = false
   mode_collabo026 = false
 
+  [patches.jpn39]
+  chs_patch = false
+
 [graphics]
 res = { x = 1920, y = 1080 }
 windowed = false

--- a/dist/config.toml
+++ b/dist/config.toml
@@ -19,6 +19,9 @@ unlock_songs = true
   [patches.jpn39]
   fix_language = false
   chs_patch = false
+  mode_collabo025 = false
+  mode_collabo026 = false
+  mode_aprilfool001 = false
 
 [graphics]
 res = { x = 1920, y = 1080 }

--- a/dist/config.toml
+++ b/dist/config.toml
@@ -17,6 +17,7 @@ unlock_songs = true
   mode_collabo026 = false
 
   [patches.jpn39]
+  fix_language = false
   chs_patch = false
 
 [graphics]

--- a/src/patches/versions/CHN00.cpp
+++ b/src/patches/versions/CHN00.cpp
@@ -100,7 +100,7 @@ Init () {
     i32 xRes            = 1920;
     i32 yRes            = 1080;
     bool unlockSongs    = true;
-    bool fixLanguage    = false;
+    bool fixLanguage     = false;
     bool demoMovie      = true;
     bool modeCollabo025 = false;
     bool modeCollabo026 = false;

--- a/src/patches/versions/CHN00.cpp
+++ b/src/patches/versions/CHN00.cpp
@@ -130,7 +130,7 @@ Init () {
             unlockSongs = readConfigBool (patches, "unlock_songs", unlockSongs);
             auto chn00  = openConfigSection (patches, "chn00");
             if (chn00) {
-                fixLanguage    = readConfigBool (chn00, "fix_language", fixLanguage);
+                fixLanguage     = readConfigBool (chn00, "fix_language", fixLanguage);
                 demoMovie      = readConfigBool (chn00, "demo_movie", demoMovie);
                 modeCollabo025 = readConfigBool (chn00, "mode_collabo025", modeCollabo025);
                 modeCollabo026 = readConfigBool (chn00, "mode_collabo026", modeCollabo026);

--- a/src/patches/versions/CHN00.cpp
+++ b/src/patches/versions/CHN00.cpp
@@ -24,9 +24,9 @@ HOOK (i32, HaspRead, PROC_ADDRESS ("hasp_windows_x64.dll", "hasp_read"), i32, i3
     return 0;
 }
 
-i64 (__fastcall *lua_settop) (u64, u64)      = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_settop");
-i64 (__fastcall *lua_pushboolean) (u64, u64) = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_pushboolean");
-i64 (__fastcall *lua_pushstring) (u64, u64)  = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_pushstring");
+FUNCTION_PTR (i64, lua_settop, PROC_ADDRESS ("lua51.dll", "lua_settop"), u64, u64);
+FUNCTION_PTR (i64, lua_pushboolean, PROC_ADDRESS ("lua51.dll", "lua_pushboolean"), u64, u64);
+FUNCTION_PTR (i64, lua_pushstring, PROC_ADDRESS ("lua51.dll", "lua_pushstring"), u64, u64);
 
 i64
 lua_pushtrue (i64 a1) {
@@ -100,7 +100,7 @@ Init () {
     i32 xRes            = 1920;
     i32 yRes            = 1080;
     bool unlockSongs    = true;
-    bool fixLanguage     = false;
+    bool fixLanguage    = false;
     bool demoMovie      = true;
     bool modeCollabo025 = false;
     bool modeCollabo026 = false;
@@ -130,7 +130,7 @@ Init () {
             unlockSongs = readConfigBool (patches, "unlock_songs", unlockSongs);
             auto chn00  = openConfigSection (patches, "chn00");
             if (chn00) {
-                fixLanguage     = readConfigBool (chn00, "fix_language", fixLanguage);
+                fixLanguage    = readConfigBool (chn00, "fix_language", fixLanguage);
                 demoMovie      = readConfigBool (chn00, "demo_movie", demoMovie);
                 modeCollabo025 = readConfigBool (chn00, "mode_collabo025", modeCollabo025);
                 modeCollabo026 = readConfigBool (chn00, "mode_collabo026", modeCollabo026);

--- a/src/patches/versions/JPN39.cpp
+++ b/src/patches/versions/JPN39.cpp
@@ -25,6 +25,11 @@ lua_pushtrue (i64 a1) {
     return 1;
 }
 
+HOOK (i64, AvailableMode_Collabo024,   ASLR (0x1402DE710), i64 a1) { return lua_pushtrue (a1); }
+HOOK (i64, AvailableMode_Collabo025,   ASLR (0x1402DE6B0), i64 a1) { return lua_pushtrue (a1); }
+HOOK (i64, AvailableMode_Collabo026,   ASLR (0x1402DE670), i64 a1) { return lua_pushtrue (a1); }
+HOOK (i64, AvailableMode_AprilFool001, ASLR (0x1402DE5B0), i64 a1) { return lua_pushtrue (a1); }
+
 const i32 datatableBufferSize = 1024 * 1024 * 12;
 safetyhook::Allocation datatableBuffer1;
 safetyhook::Allocation datatableBuffer2;
@@ -89,11 +94,14 @@ HOOK (i64, GetCabinetLanguage, ASLR (0x1401D1A60), i64, i64 a2) {
 
 void
 Init () {
-    i32 xRes         = 1920;
-    i32 yRes         = 1080;
-    bool unlockSongs = true;
-    bool fixLanguage  = false;
-    bool chsPatch    = false;
+    i32 xRes              = 1920;
+    i32 yRes              = 1080;
+    bool unlockSongs      = true;
+    bool fixLanguage       = false;
+    bool chsPatch         = false;
+    bool modeCollabo025   = false;
+    bool modeCollabo026   = false;
+    bool modeAprilFool001 = false;
 
     auto configPath = std::filesystem::current_path () / "config.toml";
     std::unique_ptr<toml_table_t, void (*) (toml_table_t *)> config_ptr (openConfig (configPath), toml_free);
@@ -103,8 +111,11 @@ Init () {
             unlockSongs = readConfigBool (patches, "unlock_songs", unlockSongs);
             auto jpn39  = openConfigSection (patches, "jpn39");
             if (jpn39) {
-                fixLanguage = readConfigBool (jpn39, "fix_language", fixLanguage);
-                chsPatch   = readConfigBool (jpn39, "chs_patch", chsPatch);
+                fixLanguage       = readConfigBool (jpn39, "fix_language", fixLanguage);
+                chsPatch         = readConfigBool (jpn39, "chs_patch", chsPatch);
+                modeCollabo025   = readConfigBool (jpn39, "mode_collabo025", modeCollabo025);
+                modeCollabo026   = readConfigBool (jpn39, "mode_collabo026", modeCollabo026);
+                modeAprilFool001 = readConfigBool (jpn39, "mode_aprilfool001", modeAprilFool001);
             }
         }
 
@@ -188,6 +199,10 @@ Init () {
         INSTALL_HOOK (GetRegionLanguage);
         INSTALL_HOOK (GetCabinetLanguage);
     }
+
+    if (modeCollabo025)   INSTALL_HOOK (AvailableMode_Collabo025);
+    if (modeCollabo026)   INSTALL_HOOK (AvailableMode_Collabo026);
+    if (modeAprilFool001) INSTALL_HOOK (AvailableMode_AprilFool001);
 
     // Disable live check
     auto amHandle = (u64)GetModuleHandle ("AMFrameWork.dll");

--- a/src/patches/versions/JPN39.cpp
+++ b/src/patches/versions/JPN39.cpp
@@ -14,9 +14,9 @@ HOOK_DYNAMIC (i64, __fastcall, curl_easy_setopt, i64 a1, i64 a2, i64 a3, i64 a4,
     return originalcurl_easy_setopt (a1, a2, a3, a4, a5);
 }
 
-i64 (__fastcall *lua_settop) (u64, u64)      = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_settop");
-i64 (__fastcall *lua_pushboolean) (u64, u64) = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_pushboolean");
-i64 (__fastcall *lua_pushstring) (u64, u64)  = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_pushstring");
+FUNCTION_PTR (i64, lua_settop, PROC_ADDRESS ("lua51.dll", "lua_settop"), u64, u64);
+FUNCTION_PTR (i64, lua_pushboolean, PROC_ADDRESS ("lua51.dll", "lua_pushboolean"), u64, u64);
+FUNCTION_PTR (i64, lua_pushstring, PROC_ADDRESS ("lua51.dll", "lua_pushstring"), u64, u64);
 
 i64
 lua_pushtrue (i64 a1) {
@@ -25,9 +25,9 @@ lua_pushtrue (i64 a1) {
     return 1;
 }
 
-HOOK (i64, AvailableMode_Collabo024,   ASLR (0x1402DE710), i64 a1) { return lua_pushtrue (a1); }
-HOOK (i64, AvailableMode_Collabo025,   ASLR (0x1402DE6B0), i64 a1) { return lua_pushtrue (a1); }
-HOOK (i64, AvailableMode_Collabo026,   ASLR (0x1402DE670), i64 a1) { return lua_pushtrue (a1); }
+HOOK (i64, AvailableMode_Collabo024, ASLR (0x1402DE710), i64 a1) { return lua_pushtrue (a1); }
+HOOK (i64, AvailableMode_Collabo025, ASLR (0x1402DE6B0), i64 a1) { return lua_pushtrue (a1); }
+HOOK (i64, AvailableMode_Collabo026, ASLR (0x1402DE670), i64 a1) { return lua_pushtrue (a1); }
 HOOK (i64, AvailableMode_AprilFool001, ASLR (0x1402DE5B0), i64 a1) { return lua_pushtrue (a1); }
 
 const i32 datatableBufferSize = 1024 * 1024 * 12;
@@ -60,8 +60,8 @@ ReplaceLeaBufferAddress (const std::vector<uintptr_t> &bufferAddresses, void *ne
 SafetyHookMid changeLanguageTypeHook{};
 
 void
-ChangeLanguageType(SafetyHookContext& ctx) {
-    int* pFontType = (int *) ctx.rax;
+ChangeLanguageType (SafetyHookContext &ctx) {
+    int *pFontType = (int *)ctx.rax;
     if (*pFontType == 4) *pFontType = 2;
 }
 
@@ -97,7 +97,7 @@ Init () {
     i32 xRes              = 1920;
     i32 yRes              = 1080;
     bool unlockSongs      = true;
-    bool fixLanguage       = false;
+    bool fixLanguage      = false;
     bool chsPatch         = false;
     bool modeCollabo025   = false;
     bool modeCollabo026   = false;
@@ -111,7 +111,7 @@ Init () {
             unlockSongs = readConfigBool (patches, "unlock_songs", unlockSongs);
             auto jpn39  = openConfigSection (patches, "jpn39");
             if (jpn39) {
-                fixLanguage       = readConfigBool (jpn39, "fix_language", fixLanguage);
+                fixLanguage      = readConfigBool (jpn39, "fix_language", fixLanguage);
                 chsPatch         = readConfigBool (jpn39, "chs_patch", chsPatch);
                 modeCollabo025   = readConfigBool (jpn39, "mode_collabo025", modeCollabo025);
                 modeCollabo026   = readConfigBool (jpn39, "mode_collabo026", modeCollabo026);
@@ -200,8 +200,8 @@ Init () {
         INSTALL_HOOK (GetCabinetLanguage);
     }
 
-    if (modeCollabo025)   INSTALL_HOOK (AvailableMode_Collabo025);
-    if (modeCollabo026)   INSTALL_HOOK (AvailableMode_Collabo026);
+    if (modeCollabo025) INSTALL_HOOK (AvailableMode_Collabo025);
+    if (modeCollabo026) INSTALL_HOOK (AvailableMode_Collabo026);
     if (modeAprilFool001) INSTALL_HOOK (AvailableMode_AprilFool001);
 
     // Disable live check

--- a/src/patches/versions/JPN39.cpp
+++ b/src/patches/versions/JPN39.cpp
@@ -14,6 +14,17 @@ HOOK_DYNAMIC (i64, __fastcall, curl_easy_setopt, i64 a1, i64 a2, i64 a3, i64 a4,
     return originalcurl_easy_setopt (a1, a2, a3, a4, a5);
 }
 
+i64 (__fastcall *lua_settop) (u64, u64)      = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_settop");
+i64 (__fastcall *lua_pushboolean) (u64, u64) = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_pushboolean");
+i64 (__fastcall *lua_pushstring) (u64, u64)  = (i64 (__fastcall *) (u64, u64))PROC_ADDRESS ("lua51.dll", "lua_pushstring");
+
+i64
+lua_pushtrue (i64 a1) {
+    lua_settop (a1, 0);
+    lua_pushboolean (a1, 1);
+    return 1;
+}
+
 const i32 datatableBufferSize = 1024 * 1024 * 12;
 safetyhook::Allocation datatableBuffer1;
 safetyhook::Allocation datatableBuffer2;
@@ -46,8 +57,34 @@ SafetyHookMid changeLanguageTypeHook{};
 void
 ChangeLanguageType(SafetyHookContext& ctx) {
     int* pFontType = (int *) ctx.rax;
-    printf("---- saftyhook 2 fontType = %d\n", *pFontType);
     if (*pFontType == 4) *pFontType = 2;
+}
+
+int language = 0;
+const char *
+languageStr () {
+    switch (language) {
+    case 1: return "en_us";
+    case 2: return "cn_tw";
+    case 3: return "kor";
+    case 4: return "cn_cn";
+    default: return "jpn";
+    }
+}
+HOOK (i64, GetLanguage, ASLR (0x140024AC0), i64 a1) {
+    auto result = originalGetLanguage (a1);
+    language    = *((u32 *)result);
+    return result;
+}
+HOOK (i64, GetRegionLanguage, ASLR (0x1401CE9B0), i64 a1) {
+    lua_settop (a1, 0);
+    lua_pushstring (a1, (u64)languageStr ());
+    return 1;
+}
+HOOK (i64, GetCabinetLanguage, ASLR (0x1401D1A60), i64, i64 a2) {
+    lua_settop (a2, 0);
+    lua_pushstring (a2, (u64)languageStr ());
+    return 1;
 }
 
 void
@@ -55,6 +92,7 @@ Init () {
     i32 xRes         = 1920;
     i32 yRes         = 1080;
     bool unlockSongs = true;
+    bool fixLanguage  = false;
     bool chsPatch    = false;
 
     auto configPath = std::filesystem::current_path () / "config.toml";
@@ -65,7 +103,8 @@ Init () {
             unlockSongs = readConfigBool (patches, "unlock_songs", unlockSongs);
             auto jpn39  = openConfigSection (patches, "jpn39");
             if (jpn39) {
-                chsPatch = readConfigBool (jpn39, "chs_patch", chsPatch);
+                fixLanguage = readConfigBool (jpn39, "fix_language", fixLanguage);
+                chsPatch   = readConfigBool (jpn39, "chs_patch", chsPatch);
             }
         }
 
@@ -132,6 +171,7 @@ Init () {
         ReplaceLeaBufferAddress (datatableBuffer3Addresses, datatableBuffer3.data ());
     }
 
+    // patch to use chs font/wordlist instead of cht
     if (chsPatch) {
         WRITE_MEMORY (ASLR (0x140CD1AE0), char, "cn_64");
         WRITE_MEMORY (ASLR (0x140CD1AF0), char, "cn_32");
@@ -140,6 +180,13 @@ Init () {
         WRITE_MEMORY (ASLR (0x140C946B0), char, "chineseSFontType");
 
         changeLanguageTypeHook = safetyhook::create_mid (ASLR (0x1400B2016), ChangeLanguageType);
+    }
+
+    // Fix language
+    if (fixLanguage) {
+        INSTALL_HOOK (GetLanguage);
+        INSTALL_HOOK (GetRegionLanguage);
+        INSTALL_HOOK (GetCabinetLanguage);
     }
 
     // Disable live check


### PR DESCRIPTION
fix_language: Make GetRegionLanguage / GetCabinetLanguage return GetLanguage value
mode_unlock: Unlock collabo_025 / collabo_026 / aprilfool_001
chs_patch: After installing Chinese for 39.06_v1.6.1, enable this can use cn font and chineseSText/chineseSFontType in wordlist.bin