### PR TITLE
Rollback to MinHook for simple hooking

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ add_project_link_arguments(
 	language: 'cpp',
 )
 
+minhook = subproject('minhook')
 tomlc99 = subproject('tomlc99')
 sdl2 = subproject('sdl2', default_options: ['default_library=static', 'test=false', 'use_render=disabled'])
 xxhash = subproject('xxhash', default_options: ['default_library=static', 'cli=false'])
@@ -52,6 +53,7 @@ pugixml_dep = pugixml.get_variable('pugixml_static_dep')
 library(
 	'bnusio',
 	link_with: [
+		minhook.get_variable('minhook_lib'),
 		tomlc99.get_variable('tomlc99_lib'),
 		sdl2.get_variable('sdl2'),
 		xxhash.get_variable('xxhash'),
@@ -61,6 +63,7 @@ library(
 	link_args : '-Wl,--allow-multiple-definition',
 	include_directories: [
 		'src',
+		minhook.get_variable('minhook_inc'),
 		tomlc99.get_variable('tomlc99_inc'),
 		sdl2.get_variable('core_inc'),
 		xxhash.get_variable('inc'),

--- a/src/bnusio.cpp
+++ b/src/bnusio.cpp
@@ -297,7 +297,7 @@ HOOK (u64, bngrw_ReqWaitTouch, PROC_ADDRESS ("bngrw.dll", "BngRwReqWaitTouch"), 
         return 1;
     } else {
         // This is called when we use an original card reader and acceptInvalidCards is set to true
-        return originalbngrw_ReqWaitTouch.call<u64> (a1, a2, a3, InspectWaitTouch, _touchData);
+        return originalbngrw_ReqWaitTouch (a1, a2, a3, InspectWaitTouch, _touchData);
     }
 }
 

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -35,7 +35,7 @@ std::string logLevelStr = "INFO";
 bool logToFile          = true;
 
 HWND hGameWnd;
-HOOK (i32, ShowMouse, PROC_ADDRESS ("user32.dll", "ShowCursor"), bool) { return originalShowMouse.call<i32> (true); }
+HOOK (i32, ShowMouse, PROC_ADDRESS ("user32.dll", "ShowCursor"), bool) { return originalShowMouse (true); }
 HOOK (i32, ExitWindows, PROC_ADDRESS ("user32.dll", "ExitWindowsEx")) { ExitProcess (0); }
 HOOK (HWND, CreateWindow, PROC_ADDRESS ("user32.dll", "CreateWindowExW"), DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle,
       i32 X, i32 Y, i32 nWidth, i32 nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam) {
@@ -43,12 +43,12 @@ HOOK (HWND, CreateWindow, PROC_ADDRESS ("user32.dll", "CreateWindowExW"), DWORD 
         if (wcscmp (lpWindowName, L"Taiko") == 0) {
             if (windowed) dwStyle = WS_TILEDWINDOW ^ WS_MAXIMIZEBOX ^ WS_THICKFRAME;
 
-            hGameWnd = originalCreateWindow.call<HWND> (dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu,
+            hGameWnd = originalCreateWindow (dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu,
                                                         hInstance, lpParam);
             return hGameWnd;
         }
     }
-    return originalCreateWindow.call<HWND> (dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance,
+    return originalCreateWindow (dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance,
                                             lpParam);
 }
 HOOK (bool, SetWindowPosition, PROC_ADDRESS ("user32.dll", "SetWindowPos"), HWND hWnd, HWND hWndInsertAfter, i32 X, i32 Y, i32 cx, i32 cy,
@@ -60,12 +60,12 @@ HOOK (bool, SetWindowPosition, PROC_ADDRESS ("user32.dll", "SetWindowPos"), HWND
         cx = (rw.right - rw.left) - (rc.right - rc.left) + cx;
         cy = (rw.bottom - rw.top) - (rc.bottom - rc.top) + cy;
     }
-    return originalSetWindowPosition.call<bool> (hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);
+    return originalSetWindowPosition (hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);
 }
 
 HOOK (void, ExitProcessHook, PROC_ADDRESS ("kernel32.dll", "ExitProcess"), u32 uExitCode) {
     bnusio::Close ();
-    originalExitProcessHook.call<void> (uExitCode);
+    originalExitProcessHook (uExitCode);
 }
 
 HOOK (i32, XinputGetState, PROC_ADDRESS ("xinput9_1_0.dll", "XInputGetState")) { return ERROR_DEVICE_NOT_CONNECTED; }
@@ -82,7 +82,7 @@ HOOK (i64, UsbFinderGetSerialNumber, PROC_ADDRESS ("nbamUsbFinder.dll", "nbamUsb
 }
 
 HOOK (i32, ws2_getaddrinfo, PROC_ADDRESS ("ws2_32.dll", "getaddrinfo"), const char *node, char *service, void *hints, void *out) {
-    return originalws2_getaddrinfo.call<i32> (server.c_str (), service, hints, out);
+    return originalws2_getaddrinfo (server.c_str (), service, hints, out);
 }
 
 void

--- a/src/patches/audio.cpp
+++ b/src/patches/audio.cpp
@@ -28,10 +28,10 @@ HOOK_DYNAMIC (i64, NUSCDeviceInit, void *a1, nusc_init_config_t *a2, nusc_init_c
     a2->device_mode      = asio;
     a2->asio_driver_name = asio ? asioDriver.c_str () : "";
     a2->wasapi_exclusive = asio ? 1 : wasapiShared ? 0 : 1;
-    return originalNUSCDeviceInit.call<i64> (a1, a2, a3, a4);
+    return originalNUSCDeviceInit (a1, a2, a3, a4);
 }
 HOOK_DYNAMIC (bool, LoadASIODriver, void *a1, const char *a2) {
-    auto result = originalLoadASIODriver.call<bool> (a1, a2);
+    auto result = originalLoadASIODriver (a1, a2);
     if (!result) {
         LogMessage (LOG_LEVEL_ERROR, (std::string ("Failed to load ASIO driver ") + asioDriver).c_str ());
         MessageBoxA (nullptr, "Failed to load ASIO driver", nullptr, MB_OK);

--- a/src/patches/dxgi.cpp
+++ b/src/patches/dxgi.cpp
@@ -10,7 +10,7 @@
 #include "dxgi1_5.h"
 #include "dxgi1_6.h"
 #include "helpers.h"
-#include <safetyhook.hpp>
+#include <MinHook.h>
 
 #include "bnusio.h"
 #include "patches.h"
@@ -21,10 +21,6 @@
  */
 
 namespace patches::Dxgi {
-
-SafetyHookInline g_origCreateDXGIFactory{};
-SafetyHookInline g_origCreateDXGIFactory2{};
-SafetyHookInline g_origD3D11CreateDeviceAndSwapChain{};
 
 // Local variables
 static bool FpsLimiterEnable = false;
@@ -40,6 +36,13 @@ static HRESULT (STDMETHODCALLTYPE *g_oldPresentWrap) (IDXGISwapChain *pSwapChain
 static HRESULT (STDMETHODCALLTYPE *g_oldPresent1Wrap) (IDXGISwapChain1 *pSwapChain, UINT SyncInterval, UINT Flags);
 static HRESULT (STDMETHODCALLTYPE *g_oldCreateSwapChain2) (IDXGIFactory2 *This, IUnknown *pDevice, DXGI_SWAP_CHAIN_DESC *pDesc,
                                                            IDXGISwapChain **ppSwapChain);
+static HRESULT (WINAPI *g_origCreateDXGIFactory2) (UINT Flags, REFIID riid, void **ppFactory);
+static HRESULT (WINAPI *g_origCreateDXGIFactory) (REFIID, void **);
+static HRESULT (WINAPI *g_origD3D11CreateDeviceAndSwapChain) (IDXGIAdapter *pAdapter, D3D_DRIVER_TYPE DriverType, HMODULE Software, UINT Flags,
+                                                              const D3D_FEATURE_LEVEL *pFeatureLevels, UINT FeatureLevels, UINT SDKVersion,
+                                                              /*const*/ DXGI_SWAP_CHAIN_DESC *pSwapChainDesc, IDXGISwapChain **ppSwapChain,
+                                                              ID3D11Device **ppDevice, D3D_FEATURE_LEVEL *pFeatureLevel,
+                                                              ID3D11DeviceContext **ppImmediateContext);
 
 static HRESULT STDMETHODCALLTYPE CreateSwapChainWrap (IDXGIFactory *This, IUnknown *pDevice, DXGI_SWAP_CHAIN_DESC *pDesc,
                                                       IDXGISwapChain **ppSwapChain);
@@ -133,7 +136,7 @@ CreateSwapChain2Wrap (IDXGIFactory2 *This, IUnknown *pDevice, DXGI_SWAP_CHAIN_DE
 
 static HRESULT WINAPI
 CreateDXGIFactory2Wrap (UINT Flags, REFIID riid, void **ppFactory) {
-    HRESULT hr = g_origCreateDXGIFactory2.call<HRESULT> (Flags, riid, ppFactory);
+    HRESULT hr = g_origCreateDXGIFactory2 (Flags, riid, ppFactory);
 
     if (SUCCEEDED (hr)) {
         IDXGIFactory2 *factory = (IDXGIFactory2 *)*ppFactory;
@@ -147,7 +150,7 @@ CreateDXGIFactory2Wrap (UINT Flags, REFIID riid, void **ppFactory) {
 
 static HRESULT WINAPI
 CreateDXGIFactoryWrap (REFIID riid, _COM_Outptr_ void **ppFactory) {
-    HRESULT hr = g_origCreateDXGIFactory.call<HRESULT> (riid, ppFactory);
+    HRESULT hr = g_origCreateDXGIFactory (riid, ppFactory);
 
     if (SUCCEEDED (hr)) {
         int factoryType = 0;
@@ -183,8 +186,8 @@ D3D11CreateDeviceAndSwapChainWrap (IDXGIAdapter *pAdapter, D3D_DRIVER_TYPE Drive
                                    const D3D_FEATURE_LEVEL *pFeatureLevels, UINT FeatureLevels, UINT SDKVersion,
                                    /*const*/ DXGI_SWAP_CHAIN_DESC *pSwapChainDesc, IDXGISwapChain **ppSwapChain, ID3D11Device **ppDevice,
                                    D3D_FEATURE_LEVEL *pFeatureLevel, ID3D11DeviceContext **ppImmediateContext) {
-    HRESULT hr = g_origD3D11CreateDeviceAndSwapChain.call<HRESULT> (pAdapter, DriverType, Software, Flags, pFeatureLevels, FeatureLevels, SDKVersion,
-                                                                    pSwapChainDesc, ppSwapChain, ppDevice, pFeatureLevel, ppImmediateContext);
+    HRESULT hr = g_origD3D11CreateDeviceAndSwapChain (pAdapter, DriverType, Software, Flags, pFeatureLevels, FeatureLevels, SDKVersion,
+                                                      pSwapChainDesc, ppSwapChain, ppDevice, pFeatureLevel, ppImmediateContext);
 
     if (ppSwapChain) {
         if (FpsLimiterEnable) {
@@ -211,10 +214,12 @@ Init () {
     FpsLimiterEnable = fpsLimit > 0;
     patches::FpsLimiter::Init ((float)fpsLimit);
 
-    g_origCreateDXGIFactory  = safetyhook::create_inline (PROC_ADDRESS ("dxgi.dll", "CreateDXGIFactory"), CreateDXGIFactoryWrap);
-    g_origCreateDXGIFactory2 = safetyhook::create_inline (PROC_ADDRESS ("dxgi.dll", "CreateDXGIFactory2"), CreateDXGIFactory2Wrap);
-    g_origD3D11CreateDeviceAndSwapChain
-        = safetyhook::create_inline (PROC_ADDRESS ("d3d11.dll", "D3D11CreateDeviceAndSwapChain"), D3D11CreateDeviceAndSwapChainWrap);
+    MH_Initialize ();
+    MH_CreateHookApi (L"dxgi.dll", "CreateDXGIFactory", (LPVOID)CreateDXGIFactoryWrap, (void **)&g_origCreateDXGIFactory);
+    MH_CreateHookApi (L"dxgi.dll", "CreateDXGIFactory2", (LPVOID)CreateDXGIFactory2Wrap, (void **)&g_origCreateDXGIFactory2);
+    MH_CreateHookApi (L"d3d11.dll", "D3D11CreateDeviceAndSwapChain", (LPVOID)D3D11CreateDeviceAndSwapChainWrap,
+                      (void **)&g_origD3D11CreateDeviceAndSwapChain);
+    MH_EnableHook (MH_ALL_HOOKS);
 }
 
 } // namespace patches::Dxgi

--- a/src/patches/layeredfs.cpp
+++ b/src/patches/layeredfs.cpp
@@ -2,7 +2,7 @@
 #include <tomcrypt.h>
 #include <zlib.h>
 
-bool useLayeredFs        = false;
+bool useLayeredFs = false;
 
 std::string datatableKey = "3530304242323633353537423431384139353134383346433246464231354534";
 std::string fumenKey     = "4434423946383537303842433443383030333843444132343339373531353830";
@@ -278,8 +278,8 @@ HOOK (HANDLE, CreateFileAHook, PROC_ADDRESS ("kernel32.dll", "CreateFileA"), LPC
         }
     }
 
-    return originalCreateFileAHook.call<HANDLE> (currentFileName.c_str (), dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition,
-                                                 dwFlagsAndAttributes, hTemplateFile);
+    return originalCreateFileAHook (currentFileName.c_str (), dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition,
+                                    dwFlagsAndAttributes, hTemplateFile);
 }
 
 // HOOK (HANDLE, CreateFileWHook, PROC_ADDRESS ("kernel32.dll", "CreateFileW"), LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,

--- a/src/patches/testmode.cpp
+++ b/src/patches/testmode.cpp
@@ -180,7 +180,7 @@ HOOK_DYNAMIC (void, TestModeSetMenuHook, u64 testModeLibrary, const wchar_t *lFi
     }
 
     LogMessage (LOG_LEVEL_DEBUG, L"TestModeLibrary load: " + fileName);
-    originalTestModeSetMenuHook.call<void> (testModeLibrary, fileName.c_str ());
+    originalTestModeSetMenuHook (testModeLibrary, fileName.c_str ());
 }
 
 void

--- a/src/patches/versions/CHN00.cpp
+++ b/src/patches/versions/CHN00.cpp
@@ -50,7 +50,7 @@ HOOK (i64, AvailableMode_Collabo026, ASLR (0x1402BC9B0), i64 a1) {
 
 HOOK (i64, GetLanguage, ASLR (0x140023720), i64 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "GetLanguage was called");
-    auto result = originalGetLanguage.call<i64> (a1);
+    auto result = originalGetLanguage (a1);
     language    = *((u32 *)result);
     return result;
 }

--- a/src/patches/versions/JPN39.cpp
+++ b/src/patches/versions/JPN39.cpp
@@ -12,15 +12,15 @@ HOOK_DYNAMIC (char, AMFWTerminate, i64) {
 
 HOOK_DYNAMIC (i64, curl_easy_setopt, i64 a1, i64 a2, i64 a3, i64 a4, i64 a5) {
     LogMessage (LOG_LEVEL_HOOKS, "Garmc curl_easy_setopt was called");
-    originalcurl_easy_setopt.call<i64> (a1, 64, 0, 0, 0);
-    originalcurl_easy_setopt.call<i64> (a1, 81, 0, 0, 0);
-    return originalcurl_easy_setopt.call<i64> (a1, a2, a3, a4, a5);
+    originalcurl_easy_setopt (a1, 64, 0, 0, 0);
+    originalcurl_easy_setopt (a1, 81, 0, 0, 0);
+    return originalcurl_easy_setopt (a1, a2, a3, a4, a5);
 }
 
 FUNCTION_PTR (i64, GetPlayDataManagerRef, ASLR (0x140024AC0), i64);
 
 i64 lua_State = 0;
-HOOK (i64, luaL_newstate, PROC_ADDRESS ("lua51.dll", "luaL_newstate")) { return lua_State = originalluaL_newstate.call<i64> (); }
+HOOK (i64, luaL_newstate, PROC_ADDRESS ("lua51.dll", "luaL_newstate")) { return lua_State = originalluaL_newstate (); }
 FUNCTION_PTR (void, lua_settop, PROC_ADDRESS ("lua51.dll", "lua_settop"), i64, i32);
 FUNCTION_PTR (void, lua_replace, PROC_ADDRESS ("lua51.dll", "lua_replace"), i64, i32);
 FUNCTION_PTR (void, lua_pushcclosure, PROC_ADDRESS ("lua51.dll", "lua_pushcclosure"), i64, i64, i32);
@@ -50,7 +50,7 @@ HOOK (i64, DeviceCheck, ASLR (0x140464FC0), i64 a1, i64 a2, i64 a3) {
     LogMessage (LOG_LEVEL_HOOKS, "DeviceCheck was called");
     TestMode::SetupAccessor (a3, RefTestModeMain);
     componentAccessor = a2;
-    return originalDeviceCheck.call<i64> (a1, a2, a3);
+    return originalDeviceCheck (a1, a2, a3);
 }
 
 int
@@ -65,34 +65,34 @@ GetUserStatus () {
 HOOK (i64, AvailableMode_Collabo024, ASLR (0x1402DE710), i64 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "AvailableMode_Collabo024 was called");
     int tournamentMode = TestMode::ReadTestModeValue (L"TournamentMode");
-    if (tournamentMode == 1) return originalAvailableMode_Collabo024.call<i64> (a1);
+    if (tournamentMode == 1) return originalAvailableMode_Collabo024 (a1);
     int status = TestMode::ReadTestModeValue (L"ModModeCollabo024");
     if (status == 1 && GetUserStatus () == 1) return lua_pushbool (a1, true);
-    return originalAvailableMode_Collabo024.call<i64> (a1);
+    return originalAvailableMode_Collabo024 (a1);
 }
 HOOK (i64, AvailableMode_Collabo025, ASLR (0x1402DE6B0), i64 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "AvailableMode_Collabo025 was called");
     int tournamentMode = TestMode::ReadTestModeValue (L"TournamentMode");
-    if (tournamentMode == 1) return originalAvailableMode_Collabo025.call<i64> (a1);
+    if (tournamentMode == 1) return originalAvailableMode_Collabo025 (a1);
     int status = TestMode::ReadTestModeValue (L"ModModeCollabo025");
     if (status == 1 && GetUserStatus () == 1) return lua_pushbool (a1, true);
-    return originalAvailableMode_Collabo025.call<i64> (a1);
+    return originalAvailableMode_Collabo025 (a1);
 }
 HOOK (i64, AvailableMode_Collabo026, ASLR (0x1402DE670), i64 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "AvailableMode_Collabo026 was called");
     int tournamentMode = TestMode::ReadTestModeValue (L"TournamentMode");
-    if (tournamentMode == 1) return originalAvailableMode_Collabo026.call<i64> (a1);
+    if (tournamentMode == 1) return originalAvailableMode_Collabo026 (a1);
     int status = TestMode::ReadTestModeValue (L"ModModeCollabo026");
     if (status == 1 && GetUserStatus () == 1) return lua_pushbool (a1, true);
-    return originalAvailableMode_Collabo026.call<i64> (a1);
+    return originalAvailableMode_Collabo026 (a1);
 }
 HOOK (i64, AvailableMode_AprilFool001, ASLR (0x1402DE5B0), i64 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "AvailableMode_AprilFool001 was called");
     int tournamentMode = TestMode::ReadTestModeValue (L"TournamentMode");
-    if (tournamentMode == 1) return originalAvailableMode_AprilFool001.call<i64> (a1);
+    if (tournamentMode == 1) return originalAvailableMode_AprilFool001 (a1);
     int status = TestMode::ReadTestModeValue (L"ModModeAprilFool001");
     if (status == 1) return lua_pushbool (a1, true);
-    return originalAvailableMode_AprilFool001.call<i64> (a1);
+    return originalAvailableMode_AprilFool001 (a1);
 }
 i64 __fastcall lua_freeze_timer (i64 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "lua_freeze_timer was called");
@@ -172,7 +172,7 @@ CHANGE_RESULT_SIZE_HOOK (ChangeResultDataSize_Enso, ASLR (0x140180074), rax);
 CHANGE_RESULT_SIZE_HOOK (ChangeResultDataSize_AI, ASLR (0x140173774), rax);
 CHANGE_RESULT_SIZE_HOOK (ChangeResultDataSize_Collabo025_026, ASLR (0x140178244), rax);
 CHANGE_RESULT_SIZE_HOOK (ChangeResultDataSize_AprilFool, ASLR (0x140176044), rax);
-  
+
 CHANGE_RESULT_INDEX_HOOK (ChangeResultDataIndex_Enso, ASLR (0x14018074B), rax, 0x34, 0x07);
 CHANGE_RESULT_INDEX_HOOK (ChangeResultDataIndex_AI, ASLR (0x140173EDD), r13, 0x24, 0x08);
 CHANGE_RESULT_INDEX_HOOK (ChangeResultDataIndex_Collabo025_026, ASLR (0x1401789AD), r13, 0x24, 0x08);
@@ -180,7 +180,7 @@ CHANGE_RESULT_INDEX_HOOK (ChangeResultDataIndex_AprilFool, ASLR (0x140176716), r
 
 HOOK (i64, GetLanguage, ASLR (0x140024AC0), i64 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "GetLanguage was called");
-    auto result = originalGetLanguage.call<i64> (a1);
+    auto result = originalGetLanguage (a1);
     language    = *((u32 *)result);
     return result;
 }
@@ -291,7 +291,7 @@ HOOK (i64, PlaySound, ASLR (0x1404C6DC0), i64 a1) {
             lua_replace (a1, -3);
         }
     }
-    return originalPlaySound.call<i64> (a1);
+    return originalPlaySound (a1);
 }
 
 HOOK (i64, PlaySoundMulti, ASLR (0x1404C6D60), i64 a1) {
@@ -303,7 +303,7 @@ HOOK (i64, PlaySoundMulti, ASLR (0x1404C6D60), i64 a1) {
             lua_replace (a1, -3);
         }
     }
-    return originalPlaySoundMulti.call<i64> (a1);
+    return originalPlaySoundMulti (a1);
 }
 
 FUNCTION_PTR (u64 *, append_chars_to_basic_string, ASLR (0x140028DA0), u64 *, const char *, size_t);
@@ -322,7 +322,7 @@ HOOK (bool, PlaySoundEnso, ASLR (0x1404ED590), u64 *a1, u64 *a2, i64 a3) {
         std::string bankName = a1[3] > 0x10 ? std::string (*((char **)a1)) : std::string ((char *)a1);
         if (bankName[0] == 'v') a2 = FixToneNameEnso (a2, bankName);
     }
-    return originalPlaySoundEnso.call<bool> (a1, a2, a3);
+    return originalPlaySoundEnso (a1, a2, a3);
 }
 
 HOOK (bool, PlaySoundSpecial, ASLR (0x1404ED230), u64 *a1, u64 *a2) {
@@ -331,13 +331,13 @@ HOOK (bool, PlaySoundSpecial, ASLR (0x1404ED230), u64 *a1, u64 *a2) {
         std::string bankName = a1[3] > 0x10 ? std::string (*((char **)a1)) : std::string ((char *)a1);
         if (bankName[0] == 'v') a2 = FixToneNameEnso (a2, bankName);
     }
-    return originalPlaySoundSpecial.call<bool> (a1, a2);
+    return originalPlaySoundSpecial (a1, a2);
 }
 
 int loaded_fail_count = 0;
 HOOK (i64, LoadedBankAll, ASLR (0x1404C69F0), i64 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "LoadedBankAll was called");
-    originalLoadedBankAll.call<i64> (a1);
+    originalLoadedBankAll (a1);
     auto result = lua_toboolean (a1, -1);
     lua_settop (a1, 0);
     if (result) {
@@ -357,12 +357,12 @@ float soundRate = 1.0F;
 HOOK (i32, SetMasterVolumeSpeaker, ASLR (0x140160330), i32 a1) {
     LogMessage (LOG_LEVEL_HOOKS, "SetMasterVolumeSpeaker was called");
     soundRate = a1 <= 100 ? 1.0F : a1 / 100.0;
-    return originalSetMasterVolumeSpeaker.call<i32> (a1 > 100 ? 100 : a1);
+    return originalSetMasterVolumeSpeaker (a1 > 100 ? 100 : a1);
 }
 
 HOOK (u64, NuscBusVolume, ASLR (0x1407B1C30), u64 a1, u64 a2, float a3) {
     LogMessage (LOG_LEVEL_HOOKS, "NuscBusVolume was called");
-    return originalNuscBusVolume.call<u64> (a1, a2, a3 * soundRate);
+    return originalNuscBusVolume (a1, a2, a3 * soundRate);
 }
 
 std::string *fontName = nullptr;
@@ -370,13 +370,13 @@ HOOK (u8, SetupFontInfo, ASLR (0x14049D820), u64 a1, u64 a2, size_t a3, u64 a4) 
     LogMessage (LOG_LEVEL_HOOKS, "SetupFontInfo was called");
     if (fontName != nullptr) delete fontName;
     fontName = new std::string (((char *)a1) + 120);
-    return originalSetupFontInfo.call<u8> (a1, a2, a3, a4);
+    return originalSetupFontInfo (a1, a2, a3, a4);
 }
 
 HOOK (u32, ReadFontInfoInt, ASLR (0x14049EAC0), u64 a1, u64 a2) {
     LogMessage (LOG_LEVEL_HOOKS, "ReadFontInfoInt was called");
     std::string attribute ((char *)a2);
-    u32 result = originalReadFontInfoInt.call<u32> (a1, a2);
+    u32 result = originalReadFontInfoInt (a1, a2);
     if (fontName->starts_with ("cn_") && attribute == "offsetV") result += 1;
     return result;
 }

--- a/subprojects/minhook.wrap
+++ b/subprojects/minhook.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/TsudaKageyu/minhook.git
+revision = master
+diff_files = minhook.patch

--- a/subprojects/packagefiles/minhook.patch
+++ b/subprojects/packagefiles/minhook.patch
@@ -1,0 +1,21 @@
+--- minhook/meson.build
++++ minhook/meson.build
+@@ -0,0 +1,18 @@
++project('minhook', 'c', version: '1.0.0')
++
++minhook_inc = include_directories('include')
++minhook_lib = static_library(
++	'minhook',
++	include_directories: minhook_inc,
++	sources: [
++		'src/buffer.c',
++		'src/hook.c',
++		'src/trampoline.c',
++		'src/hde/hde32.c',
++		'src/hde/hde64.c'
++	]
++)
++minhook_dep = declare_dependency(
++	link_with: minhook_lib,
++	include_directories: minhook_inc,
++)


### PR DESCRIPTION
This fixes a bug on startup for users using wasapi audio.
Safetyhook is way faster but is causing instability on some computers.