### PR TITLE
[cmake][fix][msvc] Add support for users with spaces in their pathnames.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ set(DEF_FILE "${CMAKE_CURRENT_SOURCE_DIR}/exports.def")
 
 if (MSVC)
     # Add the .def file to the target properties
-    set_target_properties(bnusio PROPERTIES LINK_FLAGS "/DEF:${DEF_FILE}")
+    set_target_properties(bnusio PROPERTIES LINK_FLAGS "/DEF:\"${DEF_FILE}\"")
 endif()
 
 add_custom_command(


### PR DESCRIPTION
[cmake][fix][msvc] Add support for users with spaces in their pathnames, by enclosing the `/DEF` link flag value in quotes.

Until now, if your path to the TaikoArcadeLoader repository contained spaces and you tried building bnusio, it would fail due to a linker error that looks something like this (from a real-world example):

> LINK : fatal error LNK1181: cannot open input file 'Hinkle\Documents\TaikoArcadeLoader\exports.def' [C:\Users\Christian Hinkle\Documents\TaikoArcadeLoader\build\bnusio.vcxproj]

Notice that it failed to open the "exports.def" file because the full file path was not used. It ignored everything preceding the last space in the string. To fix this, we wrap the file path value in quotes, to indicate that the entire string (including spaces) should be treated as a single argument.

## Screenshot of Build Output Before Fix

<img width="1312" height="538" alt="image" src="https://github.com/user-attachments/assets/587fc088-005a-45fe-9db7-67fc2f84b262" />

## Results After Fix

The fix is a one-line change which results in a successful build.
