### PR TITLE
Reserve low address memory for LuaJIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ set(SOURCES
     # src/patches/qr.cpp
     src/patches/layeredfs.cpp
     src/patches/testmode.cpp
+    src/patches/luajit_mem_reserve.cpp
     src/patches/versions/JPN00.cpp
     src/patches/versions/JPN08.cpp
     src/patches/versions/JPN39.cpp

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ version = "auto"            # Patch version
                             # | - JPN39: For use with Taiko JPN 39.06
                             # | - CHN00: For use with Taiko CHN 00.32
 unlock_songs = true         # not active for JPN39 (see TestMode)
+luajit_reserve_mem = 512    # in MB. reserve low address memory for LuaJIT for mitigating crashing issue, use 0 for not reserving
 
 [patches.chn00]             # These patches are only available for version CHN00
 fix_language = false        # Sync test mode language to attract etc

--- a/dist/config.toml
+++ b/dist/config.toml
@@ -15,7 +15,7 @@ version = "auto"            # Patch version
                             # | - JPN39: For use with Taiko JPN 39.06
                             # | - CHN00: For use with Taiko CHN 00.32
 unlock_songs = true
-
+luajit_reserve_mem = 512    # in MB. reserve low address memory for LuaJIT for mitigating crashing issue, use 0 for not reserving
 
 [patches.chn00]             # These patches are only available for version CHN00
 fix_language = false        # Sync test mode language to attract etc

--- a/src/bnusio.cpp
+++ b/src/bnusio.cpp
@@ -411,6 +411,7 @@ void
 Close () {
     if (autoIme) ActivateKeyboardLayout (currentLayout, KLF_SETFORPROCESS);
     patches::Plugins::Exit ();
+    patches::LuaJITMem::Exit ();
     CleanupLogger ();
 }
 } // namespace bnusio

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -249,6 +249,7 @@ DllMain (HMODULE module, const DWORD reason, LPVOID reserved) {
         INSTALL_HOOK (ws2_getaddrinfo);
 
         bnusio::Init ();
+        patches::LuaJITMem::Init (luajitReserveSize);
 
         switch (gameVersion) {
         case GameVersion::UNKNOWN: break;
@@ -264,7 +265,6 @@ DllMain (HMODULE module, const DWORD reason, LPVOID reserved) {
         patches::AmAuth::Init ();
         patches::LayeredFs::Init ();
         patches::TestMode::Init ();
-        patches::LuaJITMem::Init (luajitReserveSize);
     }
     return true;
 }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -150,6 +150,7 @@ DllMain (HMODULE module, const DWORD reason, LPVOID reserved) {
         LogMessage (LogLevel::INFO, "Loading config...");
 
         std::string version                    = "auto";
+        size_t luajitReserveSize               = 512;
         const std::filesystem::path configPath = std::filesystem::current_path () / "config.toml";
         const std::unique_ptr<toml_table_t, void (*) (toml_table_t *)> config_ptr (openConfig (configPath), toml_free);
         if (config_ptr) {
@@ -171,7 +172,10 @@ DllMain (HMODULE module, const DWORD reason, LPVOID reserved) {
                 std::strcat (placeId, countryCode.c_str ());
                 std::strcat (placeId, "0FF0");
             }
-            if (const auto patches = openConfigSection (config, "patches")) version = readConfigString (patches, "version", version);
+            if (const auto patches = openConfigSection (config, "patches")) {
+                version           = readConfigString (patches, "version", version);
+                luajitReserveSize = readConfigInt (patches, "luajit_reserve_mem", luajitReserveSize);
+            }
             if (const auto emulation = openConfigSection (config, "emulation")) {
                 emulateUsio        = readConfigBool (emulation, "usio", emulateUsio);
                 emulateCardReader  = readConfigBool (emulation, "card_reader", emulateCardReader);
@@ -260,6 +264,7 @@ DllMain (HMODULE module, const DWORD reason, LPVOID reserved) {
         patches::AmAuth::Init ();
         patches::LayeredFs::Init ();
         patches::TestMode::Init ();
+        patches::LuaJITMem::Init (luajitReserveSize);
     }
     return true;
 }

--- a/src/patches/luajit_mem_reserve.cpp
+++ b/src/patches/luajit_mem_reserve.cpp
@@ -1,35 +1,119 @@
 #include "helpers.h"
 #include "patches.h"
+#include <atomic>
+#include <cstddef>
+#include <cstring>
+#include <cassert>
 
 namespace patches::LuaJITMem {
 namespace {
 HMODULE ntdll;
 long (*avm) (HANDLE handle, void **addr, ULONG zbits, size_t *size, ULONG alloctype, ULONG prot);
-long (*fvm) (HANDLE handle, void **addr, size_t *size, ULONG freetype);
 void *reserved_mem;
-size_t reserved_size = 0;
+size_t reserved_size               = 0;
+std::atomic_size_t reserved_offset = 0;
 
-long
-avm_hook (HANDLE handle, void **addr, ULONG zbits, size_t *size, ULONG alloctype, ULONG prot) {
-    // LuaJIT call this api with zero bits set to 1
-    if (zbits == 1 && reserved_mem) {
-        LogMessage (LogLevel::INFO, "Freeing reserved memory for LuaJIT...");
-        auto free_size = size_t{0};
-        auto err       = fvm (INVALID_HANDLE_VALUE, &reserved_mem, &free_size, MEM_RELEASE);
-        if (err == 0) {
-            reserved_mem  = nullptr;
-            reserved_size = 0;
-        } else {
-            LogMessage (LogLevel::ERROR, "Failed to free reserved memory for LuaJIT: {:x}", err);
-        }
-    }
+struct alignas (MEMORY_ALLOCATION_ALIGNMENT) AllocationHeader {
+    SLIST_ENTRY entry;
+    size_t size;
+    size_t block_size;
+    u32 class_index;
+};
 
-    return avm (handle, addr, zbits, size, alloctype, prot);
+constexpr size_t ALIGNMENT      = alignof (std::max_align_t);
+constexpr size_t MIN_BLOCK_SIZE = 64;
+constexpr size_t NUM_CLASSES    = 24;
+constexpr size_t HEADER_SIZE    = (sizeof (AllocationHeader) + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
+
+alignas (MEMORY_ALLOCATION_ALIGNMENT) SLIST_HEADER free_lists[NUM_CLASSES];
+
+size_t
+align_size (size_t size) {
+    return (size + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
 }
 
-HOOK (void *, _get_proc_address, PROC_ADDRESS ("kernel32.dll", "GetProcAddress"), HANDLE dll, const char *proc) {
-    if (dll == ntdll && !IS_INTRESOURCE (proc) && !strcmp (proc, "NtAllocateVirtualMemory")) return avm_hook;
-    return original_get_proc_address (dll, proc);
+size_t
+class_index_for (size_t size) {
+    size_t block_size = MIN_BLOCK_SIZE;
+    for (size_t i = 0; i < NUM_CLASSES; i++) {
+        if (size <= block_size) return i;
+        block_size <<= 1;
+    }
+    return NUM_CLASSES;
+}
+
+void *
+alloc_from_reserved (size_t size) {
+    const auto total_size  = HEADER_SIZE + size;
+    const auto class_index = class_index_for (total_size);
+    if (class_index >= NUM_CLASSES) {
+        LogMessage (LogLevel::ERROR, "0x{:x} is too big for allocating on reserved space!", size);
+        throw std::runtime_error{"Requesting too big memory."};
+    }
+
+    const auto block_size = MIN_BLOCK_SIZE << class_index;
+    if (auto entry = InterlockedPopEntrySList (&free_lists[class_index])) {
+        auto block  = reinterpret_cast<AllocationHeader *> (entry);
+        block->size = size;
+        return reinterpret_cast<char *> (block) + HEADER_SIZE;
+    }
+
+    const auto offset = reserved_offset.fetch_add (block_size, std::memory_order_relaxed);
+    if (offset > reserved_size || block_size > reserved_size - offset) {
+        reserved_offset.fetch_sub (block_size, std::memory_order_relaxed);
+
+        LogMessage (LogLevel::ERROR, "Failed to allocate 0x{:x} on reserved space, consider increasing luajit_reserve_mem!", size);
+        throw std::runtime_error{"Failed to allocate memory for LuaJIT."};
+    }
+
+    auto block         = reinterpret_cast<AllocationHeader *> (reinterpret_cast<char *> (reserved_mem) + offset);
+    block->size        = size;
+    block->block_size  = block_size;
+    block->class_index = static_cast<u32> (class_index);
+    return reinterpret_cast<char *> (block) + HEADER_SIZE;
+}
+
+void
+free_reserved (void *ptr) {
+    auto block       = reinterpret_cast<AllocationHeader *> (reinterpret_cast<char *> (ptr) - HEADER_SIZE);
+    const auto index = block->class_index;
+    InterlockedPushEntrySList (&free_lists[index], &block->entry);
+}
+
+void *
+lj_alloc_f (void *msp, void *ptr, size_t osize, size_t nsize) {
+    (void)msp;
+    (void)osize;
+
+    if (!reserved_mem || !reserved_size) return nullptr;
+
+    if (nsize == 0) {
+        if (!ptr) return nullptr;
+        free_reserved (ptr);
+        return nullptr;
+    }
+
+    const auto size = align_size (nsize);
+
+    if (!ptr) return alloc_from_reserved (size);
+
+    auto block = reinterpret_cast<AllocationHeader *> (reinterpret_cast<char *> (ptr) - HEADER_SIZE);
+    if (block->size >= size) {
+        block->size = size;
+        return ptr;
+    }
+
+    if (block->block_size >= HEADER_SIZE + size) {
+        block->size = size;
+        return ptr;
+    }
+
+    auto new_ptr = alloc_from_reserved (size);
+
+    std::memcpy (new_ptr, ptr, std::min (block->size, size));
+    free_reserved (ptr);
+
+    return new_ptr;
 }
 
 }
@@ -46,15 +130,14 @@ Init (size_t reserveSizeMB) {
     }
 
     avm = reinterpret_cast<decltype (avm)> (GetProcAddress (ntdll, "NtAllocateVirtualMemory"));
-    fvm = reinterpret_cast<decltype (fvm)> (GetProcAddress (ntdll, "NtFreeVirtualMemory"));
-    if (!avm || !fvm) {
-        LogMessage (LogLevel::ERROR, "Failed to get NtAllocateVirtualMemory or NtFreeVirtualMemory");
+    if (!avm) {
+        LogMessage (LogLevel::ERROR, "Failed to get NtAllocateVirtualMemory");
         return;
     }
 
     reserved_mem  = nullptr;
     reserved_size = reserveSizeMB * 1024 * 1024;
-    auto err      = avm (INVALID_HANDLE_VALUE, &reserved_mem, 1, &reserved_size, MEM_RESERVE, PAGE_NOACCESS);
+    auto err      = avm (INVALID_HANDLE_VALUE, &reserved_mem, 1, &reserved_size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
 
     if (err != 0) {
         LogMessage (LogLevel::ERROR, "Failed to reserve low address memory for LuaJIT: {:x}", err);
@@ -63,6 +146,33 @@ Init (size_t reserveSizeMB) {
 
     LogMessage (LogLevel::INFO, "Reserved {}MB for LuaJIT at {}", reserved_size / 1024.f / 1024.f, reserved_mem);
 
-    INSTALL_HOOK (_get_proc_address);
+    if (reserved_size <= HEADER_SIZE) {
+        LogMessage (LogLevel::ERROR, "Reserved LuaJIT memory is too small");
+        reserved_mem  = nullptr;
+        reserved_size = 0;
+        return;
+    }
+
+    reserved_offset.store (0, std::memory_order_relaxed);
+    for (auto &free_list : free_lists)
+        InitializeSListHead (&free_list);
+
+    auto luajit = LoadLibraryA ("lua51.dll");
+    assert (luajit);
+
+    auto luaL_newstate_ptr = reinterpret_cast<uintptr_t> (GetProcAddress (luajit, "luaL_newstate"));
+    assert (luaL_newstate_ptr);
+
+    // don't call lj_alloc_create
+    WRITE_NOP (luaL_newstate_ptr + 4, 5);
+    WRITE_MEMORY (luaL_newstate_ptr + 0xC, u8, 0xEB);
+    // use our own allocator
+    WRITE_MEMORY (luaL_newstate_ptr + 0x13, u8, 0x48, 0xB9);
+    WRITE_MEMORY (luaL_newstate_ptr + 0x15, void *, lj_alloc_f);
+}
+
+void
+Exit () {
+    if (reserved_mem) VirtualFree (reserved_mem, 0, MEM_RELEASE);
 }
 }

--- a/src/patches/luajit_mem_reserve.cpp
+++ b/src/patches/luajit_mem_reserve.cpp
@@ -1,0 +1,68 @@
+#include "helpers.h"
+#include "patches.h"
+
+namespace patches::LuaJITMem {
+namespace {
+HMODULE ntdll;
+long (*avm) (HANDLE handle, void **addr, ULONG zbits, size_t *size, ULONG alloctype, ULONG prot);
+long (*fvm) (HANDLE handle, void **addr, size_t *size, ULONG freetype);
+void *reserved_mem;
+size_t reserved_size = 0;
+
+long
+avm_hook (HANDLE handle, void **addr, ULONG zbits, size_t *size, ULONG alloctype, ULONG prot) {
+    // LuaJIT call this api with zero bits set to 1
+    if (zbits == 1 && reserved_mem) {
+        LogMessage (LogLevel::INFO, "Freeing reserved memory for LuaJIT...");
+        auto free_size = size_t{0};
+        auto err       = fvm (INVALID_HANDLE_VALUE, &reserved_mem, &free_size, MEM_RELEASE);
+        if (err == 0) {
+            reserved_mem  = nullptr;
+            reserved_size = 0;
+        } else {
+            LogMessage (LogLevel::ERROR, "Failed to free reserved memory for LuaJIT: {:x}", err);
+        }
+    }
+
+    return avm (handle, addr, zbits, size, alloctype, prot);
+}
+
+HOOK (void *, _get_proc_address, PROC_ADDRESS ("kernel32.dll", "GetProcAddress"), HANDLE dll, const char *proc) {
+    if (dll == ntdll && !IS_INTRESOURCE (proc) && !strcmp (proc, "NtAllocateVirtualMemory")) return avm_hook;
+    return original_get_proc_address (dll, proc);
+}
+
+}
+
+void
+Init (size_t reserveSizeMB) {
+    if (!reserveSizeMB) return;
+
+    ntdll = GetModuleHandleA ("ntdll.dll");
+
+    if (!ntdll) {
+        LogMessage (LogLevel::ERROR, "Failed to get ntdll");
+        return;
+    }
+
+    avm = reinterpret_cast<decltype (avm)> (GetProcAddress (ntdll, "NtAllocateVirtualMemory"));
+    fvm = reinterpret_cast<decltype (fvm)> (GetProcAddress (ntdll, "NtFreeVirtualMemory"));
+    if (!avm || !fvm) {
+        LogMessage (LogLevel::ERROR, "Failed to get NtAllocateVirtualMemory or NtFreeVirtualMemory");
+        return;
+    }
+
+    reserved_mem  = nullptr;
+    reserved_size = reserveSizeMB * 1024 * 1024;
+    auto err      = avm (INVALID_HANDLE_VALUE, &reserved_mem, 1, &reserved_size, MEM_RESERVE, PAGE_NOACCESS);
+
+    if (err != 0) {
+        LogMessage (LogLevel::ERROR, "Failed to reserve low address memory for LuaJIT: {:x}", err);
+        return;
+    }
+
+    LogMessage (LogLevel::INFO, "Reserved {}MB for LuaJIT at {}", reserved_size / 1024.f / 1024.f, reserved_mem);
+
+    INSTALL_HOOK (_get_proc_address);
+}
+}

--- a/src/patches/patches.h
+++ b/src/patches/patches.h
@@ -115,6 +115,7 @@ std::vector<uint8_t> &ReadQRImage (std::vector<uint8_t> &buffer);
 } // namespace Qr
 } // namespace Scanner
 namespace LuaJITMem {
-void Init       (size_t reserveSizeMB);
+void Init              (size_t reserveSizeMB);
+void Exit              ();
 }
 } // namespace patches

--- a/src/patches/patches.h
+++ b/src/patches/patches.h
@@ -114,4 +114,7 @@ std::vector<uint8_t> &ReadQRData  (std::vector<uint8_t> &buffer);
 std::vector<uint8_t> &ReadQRImage (std::vector<uint8_t> &buffer);
 } // namespace Qr
 } // namespace Scanner
+namespace LuaJITMem {
+void Init       (size_t reserveSizeMB);
+}
 } // namespace patches


### PR DESCRIPTION
This fixes crashing issue on `lua_newuserdata` calls for me.

A better approach is enable GC64 for LuaJIT I think