### PR TITLE
Fix the ``card.ini`` generation so the working buffer is properly NULL-terminated

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -130,12 +130,19 @@ CreateCard () {
     srand (static_cast<unsigned int> (time (nullptr)));
 
     std::generate_n (buf, 20, [&] { return hexCharacterTable[rand () % 10]; });
+    buf[20] = '\0';
     WritePrivateProfileStringA ("card", "accessCode1", buf, ".\\card.ini");
+    
     std::generate_n (buf, 32, [&] { return hexCharacterTable[rand () % 16]; });
+    buf[32] = '\0';
     WritePrivateProfileStringA ("card", "chipId1", buf, ".\\card.ini");
+
     std::generate_n (buf, 20, [&] { return hexCharacterTable[rand () % 10]; });
+    buf[20] = '\0';
     WritePrivateProfileStringA ("card", "accessCode2", buf, ".\\card.ini");
+
     std::generate_n (buf, 32, [&] { return hexCharacterTable[rand () % 16]; });
+    buf[32] = '\0';
     WritePrivateProfileStringA ("card", "chipId2", buf, ".\\card.ini");
 }
 


### PR DESCRIPTION
# The bug

In the [``CreateCard()`` function of ``dllmain.cpp``](https://github.com/esuo1198/TaikoArcadeLoader/blob/94c0bcd3651f7cac7ef31b9c36379a670d7ff163/src/dllmain.cpp#L132-L139), the ``buf`` buffer is not properly NULL-terminated when Access Codes & Chip IDs are generated.

This leads to the second access code being comprised of extra values carried over from the first chip ID, as detailed here:

```cpp
	// Allocation of buf on the stack, initiated to all 0s
	char buf[64] = {};
	
	// 20 random bytes are generated info buf. The 21st byte is 0 since it was initialized as-is
	std::generate_n (buf, 20, [&] { return hexCharacterTable[rand () % 10]; });
	WritePrivateProfileStringA ("card", "accessCode1", buf, ".\\card.ini");
	// 32 random bytes are generated info buf. The 33rd byte is 0 since it was initialized as-is
	std::generate_n (buf, 32, [&] { return hexCharacterTable[rand () % 16]; });
	WritePrivateProfileStringA ("card", "chipId1", buf, ".\\card.ini");
	// 20 random bytes are generated info buf.
	// Uh-oh! The 21st byte is NOT 0 since it was overwritten by the previous calls. The next NULL byte is the 33rd!
	std::generate_n (buf, 20, [&] { return hexCharacterTable[rand () % 10]; });
	WritePrivateProfileStringA ("card", "accessCode2", buf, ".\\card.ini");
	// 32 random bytes are generated info buf. The 33rd byte is 0 since it was initialized as-is
	std::generate_n (buf, 32, [&] { return hexCharacterTable[rand () % 16]; });
	WritePrivateProfileStringA ("card", "chipId2", buf, ".\\card.ini");
```

In my case, the following ``card.ini`` was generated:

```ini
[card]
accessCode1=52211103946122567701
chipId1=FFBD331CB9B4BA1144BC7D5209260E29
accessCode2=409590800937577879997D5209260E29
chipId2=213F45FED99CF2411C68F3F603988EFD
```

The ``accessCode2`` key has 32 characters instead of 20, the last 12 of which are the same as those from ``chipId1`` key.

# The fix

I simply made it so a NULL byte is added at the correct index after each generation:

```cpp
    std::generate_n (buf, 20, [&] { return hexCharacterTable[rand () % 10]; });
    buf[20] = '\0';
    WritePrivateProfileStringA ("card", "accessCode1", buf, ".\\card.ini");
    
    std::generate_n (buf, 32, [&] { return hexCharacterTable[rand () % 16]; });
    buf[32] = '\0';
    WritePrivateProfileStringA ("card", "chipId1", buf, ".\\card.ini");

    std::generate_n (buf, 20, [&] { return hexCharacterTable[rand () % 10]; });
    buf[20] = '\0';
    WritePrivateProfileStringA ("card", "accessCode2", buf, ".\\card.ini");

    std::generate_n (buf, 32, [&] { return hexCharacterTable[rand () % 16]; });
    buf[32] = '\0';
    WritePrivateProfileStringA ("card", "chipId2", buf, ".\\card.ini");
```

This could be further optimized by just swapping the order of each statement so access codes are generated first and chip IDs are generated after, so no extra bytes would be carried over, but this would change the order of values in new ``card.ini`` files :(